### PR TITLE
Fixes #388: Table sorting was broken after recent UI update. Had forg…

### DIFF
--- a/src/main/java/org/openpnp/gui/FeedersPanel.java
+++ b/src/main/java/org/openpnp/gui/FeedersPanel.java
@@ -213,8 +213,9 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             
             for (int i = 0; i < tableModel.getRowCount(); i++) {
                 if (tableModel.getFeeder(i) == event.feeder) {
-                    table.getSelectionModel().setSelectionInterval(i, i);
-                    table.scrollRectToVisible(new Rectangle(table.getCellRect(i, 0, true)));
+                    int index = table.convertRowIndexToView(i);
+                    table.getSelectionModel().setSelectionInterval(index, index);
+                    table.scrollRectToVisible(new Rectangle(table.getCellRect(index, 0, true)));
                     break;
                 }
             }
@@ -238,7 +239,9 @@ public class FeedersPanel extends JPanel implements WizardContainer {
             table.getSelectionModel().clearSelection();
             for (int i = 0; i < tableModel.getRowCount(); i++) {
                 if (tableModel.getFeeder(i).getPart() == part) {
-                    table.getSelectionModel().setSelectionInterval(0, i);
+                    int index = table.convertRowIndexToView(i);
+                    table.getSelectionModel().setSelectionInterval(index, index);
+                    table.scrollRectToVisible(new Rectangle(table.getCellRect(index, 0, true)));
                     break;
                 }
             }

--- a/src/main/java/org/openpnp/gui/JobPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPanel.java
@@ -100,9 +100,6 @@ public class JobPanel extends JPanel {
         Finished
     }
 
-    @SuppressWarnings("unused")
-
-    
     final private Configuration configuration;
     final private MainFrame frame;
 
@@ -334,8 +331,9 @@ public class JobPanel extends JPanel {
     private void selectBoardLocation(BoardLocation boardLocation) {
         for (int i = 0; i < boardLocationsTableModel.getRowCount(); i++) {
             if (boardLocationsTableModel.getBoardLocation(i) == boardLocation) {
-                boardLocationsTable.getSelectionModel().setSelectionInterval(i, i);
-                boardLocationsTable.scrollRectToVisible(new Rectangle(boardLocationsTable.getCellRect(i, 0, true)));
+                int index = boardLocationsTable.convertRowIndexToView(i);
+                boardLocationsTable.getSelectionModel().setSelectionInterval(index, index);
+                boardLocationsTable.scrollRectToVisible(new Rectangle(boardLocationsTable.getCellRect(index, 0, true)));
                 break;
             }
         }
@@ -929,10 +927,8 @@ public class JobPanel extends JPanel {
 
         @Override
         public void actionPerformed(ActionEvent arg0) {
-            int index = boardLocationsTable.getSelectedRow();
-            if (index != -1) {
-                index = boardLocationsTable.convertRowIndexToModel(index);
-                BoardLocation boardLocation = getJob().getBoardLocations().get(index);
+            BoardLocation boardLocation = getSelectedBoardLocation();
+            if (boardLocation != null) {
                 getJob().removeBoardLocation(boardLocation);
                 boardLocationsTableModel.fireTableDataChanged();
             }

--- a/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
+++ b/src/main/java/org/openpnp/gui/JobPlacementsPanel.java
@@ -25,13 +25,11 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JToolBar;
 import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
 import javax.swing.border.LineBorder;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
 
-import org.openpnp.events.BoardLocationSelectedEvent;
 import org.openpnp.events.PlacementSelectedEvent;
 import org.openpnp.gui.components.AutoSelectTextTable;
 import org.openpnp.gui.support.ActionGroup;
@@ -57,8 +55,6 @@ import org.openpnp.spi.Nozzle;
 import org.openpnp.util.MovableUtils;
 import org.openpnp.util.UiUtils;
 import org.openpnp.util.Utils2D;
-
-import com.google.common.eventbus.Subscribe;
 
 public class JobPlacementsPanel extends JPanel {
     private JTable table;
@@ -221,8 +217,9 @@ public class JobPlacementsPanel extends JPanel {
     public void selectPlacement(Placement placement) {
         for (int i = 0; i < tableModel.getRowCount(); i++) {
             if (tableModel.getPlacement(i) == placement) {
-                table.getSelectionModel().setSelectionInterval(i, i);
-                table.scrollRectToVisible(new Rectangle(table.getCellRect(i, 0, true)));
+                int index = table.convertRowIndexToView(i);
+                table.getSelectionModel().setSelectionInterval(index, index);
+                table.scrollRectToVisible(new Rectangle(table.getCellRect(index, 0, true)));
                 break;
             }
         }


### PR DESCRIPTION
…otten to convert indexes when selecting objects in tables on Job, Placements and Feeders, which caused the event bus selection events to loop forever with bad indexes when the table was sorted by anything other than default.